### PR TITLE
Update to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "6"
   - "5"
-  - "4"

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apollostack/GitHunt.git"
+    "url": "git+https://github.com/apollographql/GitHunt.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/apollostack/GitHunt/issues"
+    "url": "https://github.com/apollographql/GitHunt/issues"
   },
-  "homepage": "https://github.com/apollostack/GitHunt#readme",
+  "homepage": "https://github.com/apollographql/GitHunt#readme",
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-eslint": "^7.0.0",
@@ -37,7 +37,6 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "apollo-client": "^0.10.0",
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
@@ -47,7 +46,7 @@
     "css-loader": "^0.26.1",
     "express": "^4.14.0",
     "graphql-anywhere": "^2.2.0",
-    "graphql-tag": "^1.2.4",
+    "graphql-tag": "^1.3.1",
     "http-proxy-middleware": "^0.17.1",
     "immutability-helper": "^2.1.0",
     "isomorphic-fetch": "^2.2.1",
@@ -55,7 +54,7 @@
     "node-emoji": "^1.3.0",
     "persistgraphql": "^0.3.0",
     "react": "^15.4.2",
-    "react-apollo": "^0.13.0",
+    "react-apollo": "^1.0.0-rc.3",
     "react-dom": "^15.1.0",
     "react-ga": "^2.1.0",
     "react-router": "^3.0.0",

--- a/ui/components/FeedEntry.js
+++ b/ui/components/FeedEntry.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import { ApolloClient } from 'apollo-client';
-import { withApollo } from 'react-apollo';
+import { gql, withApollo, ApolloClient } from 'react-apollo';
 import { Link } from 'react-router';
-import gql from 'graphql-tag';
 import { filter, propType } from 'graphql-anywhere';
 
 import VoteButtons from './VoteButtons';

--- a/ui/components/Profile.js
+++ b/ui/components/Profile.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
+import { gql, graphql } from 'react-apollo';
 import { Link } from 'react-router';
 
 function Profile({ loading, currentUser }) {
@@ -57,7 +56,9 @@ const PROFILE_QUERY = gql`
 `;
 
 export default graphql(PROFILE_QUERY, {
-  options: { forceFetch: true },
+  options: {
+    fetchPolicy: 'network-only',
+  },
   props: ({ data: { loading, currentUser } }) => ({
     loading, currentUser,
   }),

--- a/ui/components/Profile.js
+++ b/ui/components/Profile.js
@@ -57,7 +57,7 @@ const PROFILE_QUERY = gql`
 
 export default graphql(PROFILE_QUERY, {
   options: {
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   },
   props: ({ data: { loading, currentUser } }) => ({
     loading, currentUser,

--- a/ui/components/RepoInfo.js
+++ b/ui/components/RepoInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import TimeAgo from 'react-timeago';
 import { emojify } from 'node-emoji';
-import gql from 'graphql-tag';
+import { gql } from 'react-apollo';
 import { propType } from 'graphql-anywhere';
 
 import InfoLabel from './InfoLabel';

--- a/ui/components/VoteButtons.js
+++ b/ui/components/VoteButtons.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import gql from 'graphql-tag';
+import { gql } from 'react-apollo';
 import { propType } from 'graphql-anywhere';
 
 export default function VoteButtons({ canVote, onVote, entry: { score, vote } }) {

--- a/ui/helpers/create-apollo-client.js
+++ b/ui/helpers/create-apollo-client.js
@@ -1,7 +1,7 @@
-import { ApolloClient, addTypename } from 'apollo-client';
+import { ApolloClient } from 'react-apollo';
 
 export default options => new ApolloClient(Object.assign({}, {
-  queryTransformer: addTypename,
+  addTypename: true,
   dataIdFromObject: (result) => {
     if (result.id && result.__typename) { // eslint-disable-line no-underscore-dangle
       return result.__typename + result.id; // eslint-disable-line no-underscore-dangle

--- a/ui/routes/FeedPage.js
+++ b/ui/routes/FeedPage.js
@@ -52,6 +52,7 @@ const withData = graphql(FEED_QUERY, {
       offset: 0,
       limit: ITEMS_PER_PAGE,
     },
+    fetchPolicy: 'cache-and-network',
   }),
   props: ({ data: { loading, feed, currentUser, fetchMore } }) => ({
     loading,

--- a/ui/routes/FeedPage.js
+++ b/ui/routes/FeedPage.js
@@ -52,7 +52,6 @@ const withData = graphql(FEED_QUERY, {
       offset: 0,
       limit: ITEMS_PER_PAGE,
     },
-    forceFetch: true,
   }),
   props: ({ data: { loading, feed, currentUser, fetchMore } }) => ({
     loading,


### PR DESCRIPTION
Closes https://github.com/apollographql/GitHunt-React/issues/218 and https://github.com/apollographql/apollo-client/issues/1429 by updating GitHunt to the 1.x rcs.

SSR is only broken because we were using some deprecated APIs like `forceFetch`.