### PR TITLE
Eliminating build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "redux": "^3.5.2",
     "style-loader": "^0.13.1",
     "subscriptions-transport-ws": "^0.5.3",
-    "webpack": "^2.2.1"
+    "webpack": "2.2.1"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
Eliminating the build error caused by webpack 2.3.0 by changing package.json to
use webpack 2.2.1