### PR TITLE
Use the @connection directive when fetching the feed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 8.1.2

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "apollo-client": "^1.6.1",
+    "apollo-client": "^1.8.0",
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "apollo-client": "^1.6.1",
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",

--- a/ui/graphql/FeedQuery.graphql
+++ b/ui/graphql/FeedQuery.graphql
@@ -7,7 +7,7 @@ query Feed($type: FeedType!, $offset: Int, $limit: Int) {
   currentUser {
     login
   }
-  feed(type: $type, offset: $offset, limit: $limit) @connection(key: "feed") {
+  feed(type: $type, offset: $offset, limit: $limit) @connection(key: "feed", filter: ["type"]) {
     ...FeedEntry
   }
 }

--- a/ui/graphql/FeedQuery.graphql
+++ b/ui/graphql/FeedQuery.graphql
@@ -7,7 +7,7 @@ query Feed($type: FeedType!, $offset: Int, $limit: Int) {
   currentUser {
     login
   }
-  feed(type: $type, offset: $offset, limit: $limit) {
+  feed(type: $type, offset: $offset, limit: $limit) @connection(key: "feed") {
     ...FeedEntry
   }
 }


### PR DESCRIPTION
This updates the client to the latest version, where the `@connection` directive causes query results for the feed to be stored in the store with a custom key.